### PR TITLE
TaskStatusDB add tasks

### DIFF
--- a/exorcist/models.py
+++ b/exorcist/models.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import TypeVar, Generic
 import dataclasses
 
 class TaskStatus(Enum):

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -116,18 +116,19 @@ class TaskStatusDB:
         }
 
         deps_data = [
-            {'from': req.taskid, 'to': task.taskid}
+            {'from': req, 'to': taskid}
             for req in requirements
         ]
         return [task_data], deps_data
 
-    def _insert_task_and_deps_data(task_data, deps_data):
+    def _insert_task_and_deps_data(self, task_data, deps_data):
         task_ins = sqla.insert(self.tasks_table).values(task_data)
         deps_ins = sqla.insert(self.dependencies_table).values(deps_data)
 
         with self.engine.begin() as conn:
             res1 = conn.execute(task_ins)
-            res2 = conn.execute(deps_ins)
+            if deps_data:  # don't insert on empty deps
+                res2 = conn.execute(deps_ins)
 
     def add_task(self, taskid: str, requirements: Iterable[str]):
         """Add a task to the database.

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -156,7 +156,7 @@ class TaskStatusDB:
         """
         all_data = [
             self._get_task_and_dep_data(node, taskid_network.pred[node])
-            for node in nx.topological_sort(taskid_network.nodes)
+            for node in nx.topological_sort(taskid_network)
         ]
         tasklists, deplists = zip(*all_data)
         tasks = sum(tasklists, [])

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -54,7 +54,9 @@ class AbstractTaskStatusDB(abc.ABC):
         Parameters
         ----------
         task_network: nx.Digraph
-            A network with taskid strings as nodes.
+            A network with taskids (str) as nodes. Edges in this graph
+            follow the direction of time/flow of information: from earlier
+            tasks to later tasks; from requirements to subsequent.
         """
         raise NotImplementedError()
 

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -2,6 +2,7 @@ import pytest
 from exorcist import TaskStatusDB, NoStatusChange, TaskStatus
 
 import sqlalchemy as sqla
+import networkx as nx
 
 def create_database(metadata, engine, extra_table=False,
                     missing_table=False, extra_column=False,
@@ -66,8 +67,34 @@ def loaded_db(fresh_db):
     add_mock_data(fresh_db.metadata, fresh_db.engine)
     return fresh_db
 
+def count_rows(db, table):
+    query = sqla.select(sqla.func.count()).select_from(table)
+    with db.engine.connect() as conn:
+        count = conn.execute(query).scalar()
+    return count
+
+def get_tasks_and_deps(db):
+    with db.engine.connect() as conn:
+        tasks = set(conn.execute(sqla.select(db.tasks_table)))
+        deps = set(conn.execute(sqla.select(db.dependencies_table)))
+    return tasks, deps
+
+@pytest.fixture
+def diamond_taskid_network():
+    graph = nx.DiGraph()
+    graph.add_nodes_from(["A", "B", "C", "D"])
+    graph.add_edges_from([("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")])
+    return graph
+
 
 class TestTaskStatusDB:
+    @staticmethod
+    def is_our_db(db):
+        return (
+            len(db.metadata.tables) == 2
+            and set(db.metadata.tables) == {'tasks', 'dependencies'}
+        )
+
     @staticmethod
     def assert_is_our_db(db):
         assert len(db.metadata.tables) == 2
@@ -76,15 +103,8 @@ class TestTaskStatusDB:
     @staticmethod
     def assert_is_fresh_db(db):
         TestTaskStatusDB.assert_is_our_db(db)
-
-        def count_rows(table):
-            query = sqla.select(sqla.func.count()).select_from(table)
-            with db.engine.connect() as conn:
-                count = conn.execute(query).scalar()
-            return count
-
-        assert count_rows(db.metadata.tables['tasks']) == 0
-        assert count_rows(db.metadata.tables['dependencies']) == 0
+        assert count_rows(db, db.metadata.tables['tasks']) == 0
+        assert count_rows(db, db.metadata.tables['dependencies']) == 0
 
     def test_fresh_db(self, fresh_db):
         # this effectively tests that the __init__ method is working
@@ -162,3 +182,26 @@ class TestTaskStatusDB:
 
         assert len(deps) == len(expected)
         assert set(deps) == expected
+
+    def test_add_task(self, fresh_db):
+        # task without prerequisites
+        fresh_db.add_task("foo", requirements=[])
+        expected_foo_task = ("foo", TaskStatus.AVAILABLE.value, None, 0)
+        tasks, deps = get_tasks_and_deps(fresh_db)
+        assert set(tasks) == {expected_foo_task}
+        assert set(deps) == set()
+
+        # task with prerequisites
+        fresh_db.add_task("bar", requirements=['foo'])
+        tasks, deps = get_tasks_and_deps(fresh_db)
+        assert set(tasks) == {expected_foo_task,
+                              ("bar", TaskStatus.BLOCKED.value, None, 0)}
+        assert set(deps) == {("foo", "bar")}
+
+    def test_add_task_before_requirements(self, fresh_db):
+        # TODO: shouldn't this error because the FK doesn't exist?
+        fresh_db.add_task("bar", requirements=["foo"])
+
+    def test_add_task_network(self, fresh_db, diamond_taskid_network):
+        # fresh_db.add_task_network(diamond_taskid_network)
+        ...

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -203,5 +203,16 @@ class TestTaskStatusDB:
         fresh_db.add_task("bar", requirements=["foo"])
 
     def test_add_task_network(self, fresh_db, diamond_taskid_network):
-        # fresh_db.add_task_network(diamond_taskid_network)
-        ...
+        fresh_db.add_task_network(diamond_taskid_network)
+        tasks, deps = get_tasks_and_deps(fresh_db)
+        expected_tasks = {
+            ("A", TaskStatus.AVAILABLE.value, None, 0),
+            ("B", TaskStatus.BLOCKED.value, None, 0),
+            ("C", TaskStatus.BLOCKED.value, None, 0),
+            ("D", TaskStatus.BLOCKED.value, None, 0),
+        }
+        expected_deps = {("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")}
+        assert set(tasks) == expected_tasks
+        assert set(deps) == expected_deps
+        assert len(tasks) == len(expected_tasks)
+        assert len(deps) == len(expected_deps)

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -199,8 +199,11 @@ class TestTaskStatusDB:
         assert set(deps) == {("foo", "bar")}
 
     def test_add_task_before_requirements(self, fresh_db):
-        # TODO: shouldn't this error because the FK doesn't exist?
-        fresh_db.add_task("bar", requirements=["foo"])
+        with pytest.raises(sqla.exc.IntegrityError, match="FOREIGN KEY"):
+            fresh_db.add_task("bar", requirements=["foo"])
+
+        # check that task insertion got rolled back
+        self.assert_is_fresh_db(fresh_db)
 
     def test_add_task_network(self, fresh_db, diamond_taskid_network):
         fresh_db.add_task_network(diamond_taskid_network)


### PR DESCRIPTION
Resolves #2.

Includes all of #9, so that one should be reviewed first.

NB: Tasks must be added in a reasonable execution order (i.e., topological sort of the DAG), because we use FK constraints on the dependencies table. So no task ID can be added to the dependencies table before it gets added to the tasks table.