### PR TITLE
Add get_all_tasks

### DIFF
--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -132,8 +132,12 @@ class TaskStatusDB(AbstractTaskStatusDB):
     def dependencies_table(self):
         return self.metadata.tables['dependencies']
 
-    def get_all_tasks(self):
-        """Yield current status for all tasks
+    def get_all_tasks(self) -> Iterable[sqla.Row]:
+        """Yield current row for all tasks.
+
+        This is mainly intended for debug and development usage; a more
+        standardized variant will likely become part of the main API when we
+        want dashboards, etc.
         """
         with self.engine.connect() as conn:
             yield from conn.execute(sqla.select(self.tasks_table)).all()

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -129,6 +129,12 @@ class TaskStatusDB(AbstractTaskStatusDB):
     def dependencies_table(self):
         return self.metadata.tables['dependencies']
 
+    def get_all_tasks(self):
+        """Yield current status for all tasks
+        """
+        with self.engine.connect() as conn:
+            yield from conn.execute(sqla.select(self.tasks_table)).all()
+
     @classmethod
     def from_filename(cls, filename: PathLike, *, overwrite: bool = False,
                     **kwargs):

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -163,3 +163,14 @@ class TestTaskStatusDB:
 
         assert len(deps) == len(expected)
         assert set(deps) == expected
+
+    @pytest.mark.parametrize('fixture', ['fresh_db', 'loaded_db'])
+    def test_get_all_tasks(self, request, fixture):
+        expected = {
+            'fresh_db': set(),
+            'loaded_db': {('foo', TaskStatus.AVAILABLE.value, None, 0, 3),
+                          ('bar', TaskStatus.BLOCKED.value, None, 0, 3)},
+        }[fixture]
+        db = request.getfixturevalue(fixture)
+        tasks = set(db.get_all_tasks())
+        assert tasks == expected


### PR DESCRIPTION
This adds `TaskStatusDB.get_all_tasks()`. This isn't something that we've put into the official API for the ABC, although we probably will eventually for dashboards, etc.

Right now, it's just a very useful convenience when developing interactively (Jupyter or PDB).

This builds on #9 and should only be reviewed/merged after that one.