### PR TITLE
TaskStatusDB: `check_out_task`

### DIFF
--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -5,7 +5,7 @@ from .models import TaskStatus
 from datetime import datetime
 
 # imports for typing
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Union
 from os import PathLike
 from sqlalchemy.sql.roles import StatementRole as SQLStatement
 
@@ -81,7 +81,7 @@ class AbstractTaskStatusDB(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def check_out_task(self) -> str | None:
+    def check_out_task(self) -> Union[str, None]:
         """
         Select a task to be run.
 

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -9,7 +9,6 @@ from typing import Optional, Iterable
 from os import PathLike
 from sqlalchemy.sql.roles import StatementRole as SQLStatement
 
-_SENTINEL = object()
 
 def _sqlite_fk_pragma(dbapi_conn, conn_record):
     """Event listener function for foreign keys in sqlite
@@ -404,7 +403,7 @@ class TaskStatusDB(AbstractTaskStatusDB):
             )
             result = conn.execute(update_stmt)
 
-        self._validate_update_result(result)
+            self._validate_update_result(result)
 
         return task_row.taskid
 

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -251,6 +251,13 @@ class TestTaskStatusDB:
 
         assert bar == ("bar", TaskStatus.BLOCKED.value, None, 0, 3)
 
+    def test_check_out_task_double_checkout(self, loaded_db):
+        taskid = loaded_db.check_out_task()
+        assert taskid == "foo"
+        # now there should be no available tasks, so a checkout here will
+        # return None
+        assert loaded_db.check_out_task() is None
+
     def test_check_out_task_empty_db(self, fresh_db):
         assert fresh_db.check_out_task() is None
 

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -232,7 +232,8 @@ class TestTaskStatusDB:
         assert len(tasks) == len(expected_tasks)
         assert len(deps) == len(expected_deps)
 
-    def test_status_update_statement(self, loaded_db):
+    def test_task_row_update_statement(self, loaded_db):
+        # TODO: I'm going to do this in a future PR
         ...
 
     def test_check_out_task(self, loaded_db):

--- a/exorcist/tests/test_taskstatusdb.py
+++ b/exorcist/tests/test_taskstatusdb.py
@@ -199,8 +199,11 @@ class TestTaskStatusDB:
         assert set(deps) == {("foo", "bar")}
 
     def test_add_task_before_requirements(self, fresh_db):
-        # TODO: shouldn't this error because the FK doesn't exist?
-        fresh_db.add_task("bar", requirements=["foo"])
+        with pytest.raises(sqla.exc.IntegrityError, match="FOREIGN KEY"):
+            fresh_db.add_task("bar", requirements=["foo"])
+
+        # check that task insertion got rolled back
+        self.assert_is_fresh_db(fresh_db)
 
     def test_add_task_network(self, fresh_db, diamond_taskid_network):
         fresh_db.add_task_network(diamond_taskid_network)


### PR DESCRIPTION
Resolves #3. Supersedes #15.

This includes all of #14, and should only be reviewed after that.