### PR TITLE
Stricter task checkout requirement

### DIFF
--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -375,6 +375,7 @@ class TaskStatusDB(AbstractTaskStatusDB):
         is_checkout: bool = False,
         max_tries: Optional[int] = None,
         old_status: Optional[TaskStatus] = None,
+        old_tries: Optional[int] = None
     ) -> SQLStatement:
         """
         Parameters
@@ -415,6 +416,9 @@ class TaskStatusDB(AbstractTaskStatusDB):
 
         if old_status is not None:
             stmt = stmt.where(self.tasks_table.c.status == old_status.value)
+
+        if old_tries is not None:
+            stmt = stmt.where(self.tasks_table.c.tries == old_tries)
 
         # create a dict of values to update
         values = {
@@ -477,7 +481,9 @@ class TaskStatusDB(AbstractTaskStatusDB):
             update_stmt = self._task_row_update_statement(
                 task_row.taskid,
                 status=TaskStatus.IN_PROGRESS,
-                is_checkout=True
+                is_checkout=True,
+                old_status=TaskStatus.AVAILABLE,
+                old_tries=task_row.tries,
             )
             result = conn.execute(update_stmt)
 


### PR DESCRIPTION
This now requires that the task that gets updated at checkout:

1. has status `AVAILABLE`
2. has the correct number of previous tries

Since these two things should be updated when the task is moved from `AVAILABLE` to `IN_PROGRESS`, this should prevent us from claiming the same task twice. The writing update is atomic, and can't be duplicated.

Now, if the same task is requested twice, this will raise a NoStatusChange. It is up to the worker to catch that and retry.

NB: This indicates that we don't actually lock the DB for the entirety of a transaction; it can still be read during that transaction, and a task that is first reading, then writing, can be occurring simultaneously. We should check the implications of this for other parts of the task lifecycle.