### PR TITLE
`TaskStatusDB.check_out_task`: Use subquery for taskid instead of separate select

### DIFF
--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -369,7 +369,7 @@ class TaskStatusDB(AbstractTaskStatusDB):
 
     def _task_row_update_statement(
         self,
-        taskid: str,
+        taskid: Union[str, SQLStatement],
         status: Union[TaskStatus, SQLStatement],
         *,
         is_checkout: bool = False,
@@ -461,52 +461,50 @@ class TaskStatusDB(AbstractTaskStatusDB):
         # TODO: may need move this to a single attempt function and wrap it
         # in while loop to catch NoStatusChange errors until we have a
         # successful checkout
-
-        # TODO: separate selection so subclasses can easily override;
-        # something like `_select_task(conn: Connection) -> Row` (allow us
-        # to do something smarter than "take the first available")
         _logger.info("Checking out a new task")
-        sel_stmt = (
-            sqla.select(self.tasks_table)
+        subq = (
+            sqla.select(self.tasks_table.c.taskid)
             .where(self.tasks_table.c.status == TaskStatus.AVAILABLE.value)
+            # .order_by(tasks_table.c.priority.desc())  # FUTURE: priority
+            .limit(1)
+            .scalar_subquery()
         )
         with self.engine.begin() as conn:
-            task_row = conn.execute(sel_stmt).first()
-            _logger.debug(f"Before claiming task: {task_row=}")
-
-            if task_row is None:
-                # no tasks are available
-                return None
-
             update_stmt = self._task_row_update_statement(
-                task_row.taskid,
+                taskid=subq,
                 status=TaskStatus.IN_PROGRESS,
                 is_checkout=True,
                 old_status=TaskStatus.AVAILABLE,
-                old_tries=task_row.tries,
-            )
-            result = conn.execute(update_stmt)
+            ).returning(self.tasks_table.c.taskid)
+            result = list(conn.execute(update_stmt))
 
-            self._validate_update_result(result)
+        if len(result) == 1:
+            taskid = result[0][0]
+        elif len(result) == 0:
+            _logger.info("Unable to select an available task")
+           return None  # skip extra logging
+        else:  # -no-cov-
+            raise RuntimeError(f"Received {len(result)} task IDs to check "
+                               "out. Something went very weird.")
 
         # log the changed row if we're doing DEBUG logging
         if _logger.isEnabledFor(logging.DEBUG):
             reselect = (
                 sqla.select(self.tasks_table)
-                .where(self.tasks_table.c.taskid == task_row.taskid)
+                .where(self.tasks_table.c.taskid == taskid)
             )
             # read-only; use connect() (no autocommit)
             with self.engine.connect() as conn:
                 reloaded = list(conn.execute(reselect).all())
 
             assert len(reloaded) == 1, \
-                    f"Got {len(reloaded)} rows for '{task_row.taskid}'"
+                    f"Got {len(reloaded)} rows for '{taskid}'"
 
             claimed = reloaded[0]
             _logger.debug(f"After claiming task: {claimed=}")
 
-        _logger.info(f"Selected task '{task_row.taskid}'")
-        return task_row.taskid
+        _logger.info(f"Selected task '{taskid}'")
+        return taskid
 
     def _mark_task_completed_failure(self, taskid: str):
         _logger.info(f"Marking try of {taskid} as failed.")

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -482,7 +482,7 @@ class TaskStatusDB(AbstractTaskStatusDB):
             taskid = result[0][0]
         elif len(result) == 0:
             _logger.info("Unable to select an available task")
-           return None  # skip extra logging
+            return None  # skip extra logging
         else:  # -no-cov-
             raise RuntimeError(f"Received {len(result)} task IDs to check "
                                "out. Something went very weird.")

--- a/exorcist/taskdb.py
+++ b/exorcist/taskdb.py
@@ -375,7 +375,6 @@ class TaskStatusDB(AbstractTaskStatusDB):
         is_checkout: bool = False,
         max_tries: Optional[int] = None,
         old_status: Optional[TaskStatus] = None,
-        old_tries: Optional[int] = None
     ) -> SQLStatement:
         """
         Parameters
@@ -416,9 +415,6 @@ class TaskStatusDB(AbstractTaskStatusDB):
 
         if old_status is not None:
             stmt = stmt.where(self.tasks_table.c.status == old_status.value)
-
-        if old_tries is not None:
-            stmt = stmt.where(self.tasks_table.c.tries == old_tries)
 
         # create a dict of values to update
         values = {


### PR DESCRIPTION
A few consequences here:

* We need to use RETURNING to get taskid: apparently with a subquery, UPDATE does not return its rows. This may limit our DB backends. (But I think we were already using RETURNING elsewhere, so that limitation was already in place. This just entrenches it further.)
* We lean heavily into trusting the DB stuff to go well. Previously, there were 3 result classes for checking out a task: (1) a taskid, (2) an indicator that no tasks are available, (3) an indicator that something went wrong in the task selection process. Now results (2) and (3) are grouped together, and can't be distinguished.
* We can no longer log the pre-checkout status of the task (we still log the post-checkout at debug level)

SQLA engine logging from checking out a task:

```
>>> t1 = db.check_out_task()
INFO:sqlalchemy.engine.Engine:BEGIN (implicit)
INFO:sqlalchemy.engine.Engine:UPDATE tasks SET status=?, last_modified=?, tries=(tasks.tries + ?) WHERE tasks.taskid = (SELECT tasks.taskid 
FROM tasks 
WHERE tasks.status = ?
 LIMIT ? OFFSET ?) AND tasks.status = ? RETURNING taskid
INFO:sqlalchemy.engine.Engine:[generated in 0.00048s] (2, '2023-08-28 12:58:01.823308', 1, 1, 1, 0, 1)
INFO:sqlalchemy.engine.Engine:COMMIT
```

Looks like we redundantly ask for the given old status, but that probably doesn't hurt anything. (Also, seeing the non-informative logging, I'm leaning more toward the change proposed in #24.